### PR TITLE
适配最新版特性，增加 `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# python module
+build/
+dist/
+*.egg-info/
+*.egg
+*.py[cod]
+__pycache__/
+*.so
+*~
+
+*.log

--- a/cv0.py
+++ b/cv0.py
@@ -1,9 +1,10 @@
-from cv2 import *
+from cv2 import getAffineTransform, warpAffine, line
+import cv2
 import numpy as np
 
 
 def show(img):
-    if img.dtype == np.float:
+    if img.dtype in (np.float64, np.float32, np.float16):
         img = (img * 255).astype(np.uint8)
     cv2.imshow('show', img)
     cv2.waitKey()
@@ -18,7 +19,7 @@ def read(img_path):
 
 def write(img, img_path, param=[]):
     with open(img_path, 'wb') as f:
-        if img.dtype in (np.float64, np.float32, np.float):
+        if img.dtype in (np.float64, np.float32, np.float16):
             img = (img * 255).astype(np.uint8)
         if param:
             _, data = cv2.imencode(img_path, img, param)


### PR DESCRIPTION
按照最新版 Python & OpenCV 特性，在 cv0.py 中
```py
from cv2 import *
```
将无法调用 `cv2.imshow` `cv0.getAffineTransform` 等；

NumPy 1.20 中移除了 `float`；

增加 `.gitignore` 以忽略缓存、日志等文件。